### PR TITLE
Add checks to make sure input_pipe is set to the first filter

### DIFF
--- a/otelib/backends/strategies.py
+++ b/otelib/backends/strategies.py
@@ -115,8 +115,8 @@ class AbstractBaseStrategy(ABC):
                 strategy.
 
         """
-        filter = _find_input_filter(self)
-        filter.input_pipe = input_pipe
+        start_filter = _find_start_filter(self)
+        start_filter.input_pipe = input_pipe
 
     def __rshift__(self, other: "AbstractBaseStrategy") -> "AbstractBaseStrategy":
         """Implements strategy concatenation using the `>>` symbol.
@@ -133,14 +133,14 @@ class AbstractBaseStrategy(ABC):
         return other
 
 
-def _find_input_filter(filter):
+def _find_start_filter(other):
     """Used by _set_input to find the input filter,
     incase of pipeline concatenation."""
 
-    while hasattr(filter, "input_pipe"):
-        pipe = filter.input_pipe
+    while hasattr(other, "input_pipe"):
+        pipe = other.input_pipe
         if hasattr(pipe, "input"):
-            filter = pipe.input
+            other = pipe.input
         else:
-            return filter
-    return filter
+            return other
+    return other

--- a/otelib/backends/strategies.py
+++ b/otelib/backends/strategies.py
@@ -115,7 +115,13 @@ class AbstractBaseStrategy(ABC):
                 strategy.
 
         """
-        self.input_pipe = input_pipe
+        while (hasattr(self, 'input_pipe')):
+            pipe = self.input_pipe
+            if hasattr(pipe, 'input'):
+                self = pipe.input
+            else:            
+                self.input_pipe=input_pipe
+                break
 
     def __rshift__(self, other: "AbstractBaseStrategy") -> "AbstractBaseStrategy":
         """Implements strategy concatenation using the `>>` symbol.

--- a/otelib/backends/strategies.py
+++ b/otelib/backends/strategies.py
@@ -115,13 +115,8 @@ class AbstractBaseStrategy(ABC):
                 strategy.
 
         """
-        while (hasattr(self, 'input_pipe')):
-            pipe = self.input_pipe
-            if hasattr(pipe, 'input'):
-                self = pipe.input
-            else:            
-                self.input_pipe=input_pipe
-                break
+        filter = _find_input_filter(self)
+        filter.input_pipe = input_pipe
 
     def __rshift__(self, other: "AbstractBaseStrategy") -> "AbstractBaseStrategy":
         """Implements strategy concatenation using the `>>` symbol.
@@ -136,3 +131,16 @@ class AbstractBaseStrategy(ABC):
         pipe = Pipe(self)
         other._set_input(pipe)
         return other
+
+
+def _find_input_filter(filter):
+    """Used by _set_input to find the input filter,
+    incase of pipeline concatenation."""
+
+    while hasattr(filter, "input_pipe"):
+        pipe = filter.input_pipe
+        if hasattr(pipe, "input"):
+            filter = pipe.input
+        else:
+            return filter
+    return filter

--- a/tests/test_pipe.py
+++ b/tests/test_pipe.py
@@ -325,3 +325,85 @@ def test_pipeing_strategies(  # pylint: disable=too-many-statements
     for key, value in session_test_content.items():
         assert key in session
         assert value == session[key]
+
+
+#    # check that id can be retrieved from joined pipes
+#    # create pipe 1
+#    data_resource1: "DataResource" = strategies.DataResource(
+#        server_url, **strategy_kwargs
+#    )
+#    dataid1 =  data_resource1.strategy_id
+#    filter1: "Filter" = strategies.Filter(server_url, **strategy_kwargs)
+#    filterid1 = filter1.strategy_id
+#    pipeline1 = filter1 >> data_resource1
+#
+#    # create pipe 2
+#    data_resource2: "DataResource" = strategies.DataResource(
+#        server_url, **strategy_kwargs
+#    )
+#    dataid2 =  data_resource2.strategy_id
+#    filter2: "Filter" = strategies.Filter(server_url, **strategy_kwargs)
+#    filterid2 = filter2.strategy_id
+#    pipeline2 = filter2 >> data_resource1
+#
+#    # create joined pipeline
+#    pipeline_joined = pipeline1 >> pipeline2
+#
+#    # confirm that we can retrieve the strategy ids
+#    pipeline_tail = pipeline_joined # or should it be pipeline head?
+#    assert pipeline_tail.strategy_id == dataid1
+#    raise Exception('tail!', pipeline_tail.strategy_id)
+#    pipeline_tail = pipeline_tail.input_pipe.input
+#    assert pipeline_tail.strategy_id == filterid1
+#    pipeline_tail = pipeline_tail.input_pipe.input
+#    assert pipeline_tail.strategy_id == dataid2
+#    pipeline_tail = pipeline_tail.input_pipe.input
+#    assert pipeline_tail.strategy_id == filterid2
+
+
+def test_pipeing_concatenate(  # pylint: disable=too-many-statements
+    backend: str,
+    server_url: str,
+) -> None:
+    """Tests for the correct chaining of resources and filters in a pipeline.
+    This function tests for issue 110: https://github.com/EMMC-ASBL/otelib/issues/110
+    """
+
+    import importlib
+
+    strategies = importlib.import_module(f"otelib.backends.{backend}")
+    server_url = server_url if backend != "python" else backend
+
+    strategy_kwargs = {}
+    if backend == "python":
+        # Setup custom cache
+        cache = {}
+        strategy_kwargs["cache"] = cache
+
+    data_resource1: "DataResource" = strategies.DataResource(
+        server_url, **strategy_kwargs
+    )
+    dataid1 = data_resource1.strategy_id
+    filter1: "Filter" = strategies.Filter(server_url, **strategy_kwargs)
+    filterid1 = filter1.strategy_id
+    pipeline1 = data_resource1 >> filter1
+
+    data_resource2: "DataResource" = strategies.DataResource(
+        server_url, **strategy_kwargs
+    )
+    dataid2 = data_resource2.strategy_id
+    filter2: "Filter" = strategies.Filter(server_url, **strategy_kwargs)
+    filterid2 = filter2.strategy_id
+    pipeline2 = data_resource2 >> filter2
+
+    pipeline_combined = pipeline1 >> pipeline2
+
+    # confirm that we can retrieve the strategy ids
+    pipeline_tail = pipeline_combined  # or should it be pipeline head?
+    assert pipeline_tail.strategy_id == dataid1
+    pipeline_tail = pipeline_tail.input_pipe.input
+    assert pipeline_tail.strategy_id == filterid1
+    pipeline_tail = pipeline_tail.input_pipe.input
+    assert pipeline_tail.strategy_id == dataid2
+    pipeline_tail = pipeline_tail.input_pipe.input
+    assert pipeline_tail.strategy_id == filterid2

--- a/tests/test_pipe.py
+++ b/tests/test_pipe.py
@@ -327,40 +327,6 @@ def test_pipeing_strategies(  # pylint: disable=too-many-statements
         assert value == session[key]
 
 
-#    # check that id can be retrieved from joined pipes
-#    # create pipe 1
-#    data_resource1: "DataResource" = strategies.DataResource(
-#        server_url, **strategy_kwargs
-#    )
-#    dataid1 =  data_resource1.strategy_id
-#    filter1: "Filter" = strategies.Filter(server_url, **strategy_kwargs)
-#    filterid1 = filter1.strategy_id
-#    pipeline1 = filter1 >> data_resource1
-#
-#    # create pipe 2
-#    data_resource2: "DataResource" = strategies.DataResource(
-#        server_url, **strategy_kwargs
-#    )
-#    dataid2 =  data_resource2.strategy_id
-#    filter2: "Filter" = strategies.Filter(server_url, **strategy_kwargs)
-#    filterid2 = filter2.strategy_id
-#    pipeline2 = filter2 >> data_resource1
-#
-#    # create joined pipeline
-#    pipeline_joined = pipeline1 >> pipeline2
-#
-#    # confirm that we can retrieve the strategy ids
-#    pipeline_tail = pipeline_joined # or should it be pipeline head?
-#    assert pipeline_tail.strategy_id == dataid1
-#    raise Exception('tail!', pipeline_tail.strategy_id)
-#    pipeline_tail = pipeline_tail.input_pipe.input
-#    assert pipeline_tail.strategy_id == filterid1
-#    pipeline_tail = pipeline_tail.input_pipe.input
-#    assert pipeline_tail.strategy_id == dataid2
-#    pipeline_tail = pipeline_tail.input_pipe.input
-#    assert pipeline_tail.strategy_id == filterid2
-
-
 def test_pipeing_concatenate(  # pylint: disable=too-many-statements
     backend: str,
     server_url: str,


### PR DESCRIPTION
# Description:
relating to issue #110 

when two filters or two pipelines are merged/connected using the **__rshift__** operator, we now add a check in the **_set_input**  function to make sure that if a pipeline is set as input to a filter, it points to the 1st filter of the pipeline. This is required so as to fetch the order of execution of the new merged pipeline (necessary to build a pipeline from the ontology /documentation etc)

## Type of change:
<!-- Put an `x` in the box that applies. -->
- [x] Bug fix.
- [ ] New feature.
- [ ] Documentation update.

## Checklist for the reviewer:
<!-- Put an `x` in the boxes that apply. These can be filled by reviewer after the PR is created. -->

This checklist should be used as a help for the reviewer.

- [x] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
