### PR TITLE
Migrate to pydantic v2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,7 +43,7 @@ repos:
       exclude: ^tests/.*$
       additional_dependencies:
         - "types-requests"
-        - "pydantic<2"
+        - "pydantic>=2,<3"
 
   - repo: local
     hooks:

--- a/otelib/backends/client.py
+++ b/otelib/backends/client.py
@@ -8,7 +8,7 @@ from otelib.backends.utils import Backend, StrategyType
 from otelib.warnings import IgnoringConfigOptions
 
 if TYPE_CHECKING:  # pragma: no cover
-    from typing import Any, Dict, Type, Union
+    from typing import Any, Union
 
     from otelib.backends.strategies import AbstractBaseStrategy
 
@@ -49,7 +49,7 @@ class AbstractBaseClient(ABC):
             )
         self._source = source
 
-    def _set_config(self, config: "Dict[str, Any]") -> None:
+    def _set_config(self, config: "dict[str, Any]") -> None:
         """Set the custom client configuration options."""
         if config:
             warnings.warn(
@@ -60,7 +60,7 @@ class AbstractBaseClient(ABC):
 
     @abstractmethod
     def _create_strategy(
-        self, strategy_cls: "Type[AbstractBaseStrategy]", **config
+        self, strategy_cls: "type[AbstractBaseStrategy]", **config
     ) -> "AbstractBaseStrategy":
         """Create a strategy.
 

--- a/otelib/backends/factories.py
+++ b/otelib/backends/factories.py
@@ -6,13 +6,13 @@ from otelib.backends.utils import Backend, StrategyType
 from otelib.exceptions import InvalidBackend, InvalidStrategy
 
 if TYPE_CHECKING:  # pragma: no cover
-    from typing import Type, Union
+    from typing import Union
 
     from otelib.backends.client import AbstractBaseClient
     from otelib.backends.strategies import AbstractBaseStrategy
 
 
-def client_factory(backend: "Union[str, Backend]") -> "Type[AbstractBaseClient]":
+def client_factory(backend: "Union[str, Backend]") -> "type[AbstractBaseClient]":
     """Return a backend client class."""
     try:
         backend = Backend(backend)
@@ -32,7 +32,7 @@ def client_factory(backend: "Union[str, Backend]") -> "Type[AbstractBaseClient]"
 
 def strategy_factory(
     backend: "Union[str, Backend]", strategy_type: "Union[str, StrategyType]"
-) -> "Type[AbstractBaseStrategy]":
+) -> "type[AbstractBaseStrategy]":
     """Return a backend-specific strategy class."""
     try:
         backend = Backend(backend)

--- a/otelib/backends/python/base.py
+++ b/otelib/backends/python/base.py
@@ -11,7 +11,7 @@ from otelib.backends.strategies import AbstractBaseStrategy
 from otelib.exceptions import ItemNotFoundInCache, PythonBackendException
 
 if TYPE_CHECKING:  # pragma: no cover
-    from typing import Any, Dict, Literal, Optional
+    from typing import Any, Literal, Optional
 
     from oteapi.models import SessionUpdate
 
@@ -29,7 +29,7 @@ class BasePythonStrategy(AbstractBaseStrategy):
 
     """
 
-    def __init__(self, source: str, cache: "Optional[Dict[str, Any]]" = None) -> None:
+    def __init__(self, source: str, cache: "Optional[dict[str, Any]]" = None) -> None:
         super().__init__(source)
 
         self.interpreter: "Optional[str]" = source
@@ -47,7 +47,7 @@ class BasePythonStrategy(AbstractBaseStrategy):
         data = self.strategy_config(**config)
 
         self.strategy_id = f"{self.strategy_name}-{uuid4()}"
-        self.cache[self.strategy_id] = data.json()
+        self.cache[self.strategy_id] = data.model_dump_json()
 
         if session_id:
             if session_id not in self.cache:
@@ -115,7 +115,7 @@ class BasePythonStrategy(AbstractBaseStrategy):
 
         self.cache[session_id].update(session_update)
 
-        return session_update.json().encode(encoding="utf-8")
+        return session_update.model_dump_json().encode(encoding="utf-8")
 
     def _sanity_checks(self, session_id: str) -> None:
         """Perform sanity checks before running a strategy method.

--- a/otelib/backends/python/client.py
+++ b/otelib/backends/python/client.py
@@ -7,11 +7,11 @@ from otelib.backends.client import AbstractBaseClient
 from otelib.exceptions import PythonBackendException
 
 if TYPE_CHECKING:  # pragma: no cover
-    from typing import Any, Dict, Type
+    from typing import Any
 
     from otelib.backends.python.base import BasePythonStrategy
 
-CACHE: "Dict[str, Any]" = {}
+CACHE: "dict[str, Any]" = {}
 
 
 # pylint: disable=duplicate-code
@@ -47,7 +47,7 @@ class OTEPythonClient(AbstractBaseClient):
         super()._validate_source(source)
 
     def _create_strategy(  # type: ignore[override]
-        self, strategy_cls: "Type[BasePythonStrategy]", **config
+        self, strategy_cls: "type[BasePythonStrategy]", **config
     ) -> "BasePythonStrategy":
         strategy = strategy_cls(self.interpreter, self._cache)
         strategy.create(**config)

--- a/otelib/backends/python/dataresource.py
+++ b/otelib/backends/python/dataresource.py
@@ -1,15 +1,11 @@
 """Common strategy for Download, Parse and Resource strategies."""
 import json
 from copy import deepcopy
-from typing import TYPE_CHECKING
 
 from oteapi.models import ResourceConfig
 from oteapi.plugins import create_strategy
 
 from otelib.backends.python.base import BasePythonStrategy
-
-if TYPE_CHECKING:  # pragma: no cover
-    from typing import Type
 
 
 class DataResource(BasePythonStrategy):
@@ -17,7 +13,7 @@ class DataResource(BasePythonStrategy):
     operations."""
 
     strategy_name = "dataresource"
-    strategy_config: "Type[ResourceConfig]" = ResourceConfig
+    strategy_config: "type[ResourceConfig]" = ResourceConfig
 
     def fetch(self, session_id: str) -> bytes:
         self._sanity_checks(session_id)
@@ -44,7 +40,7 @@ class DataResource(BasePythonStrategy):
             )
             self.cache[session_id].update(session_update)
 
-        return session_update.json().encode(encoding="utf-8")
+        return session_update.model_dump_json().encode(encoding="utf-8")
 
     def initialize(self, session_id: str) -> bytes:
         self._sanity_checks(session_id)
@@ -71,4 +67,4 @@ class DataResource(BasePythonStrategy):
             )
             self.cache[session_id].update(session_update)
 
-        return session_update.json().encode(encoding="utf-8")
+        return session_update.model_dump_json().encode(encoding="utf-8")

--- a/otelib/backends/python/filter.py
+++ b/otelib/backends/python/filter.py
@@ -1,12 +1,7 @@
 """Filter strategy."""
-from typing import TYPE_CHECKING
-
 from oteapi.models import FilterConfig
 
 from otelib.backends.python.base import BasePythonStrategy
-
-if TYPE_CHECKING:  # pragma: no cover
-    from typing import Type
 
 
 class Filter(BasePythonStrategy):
@@ -14,4 +9,4 @@ class Filter(BasePythonStrategy):
     operations."""
 
     strategy_name = "filter"
-    strategy_config: "Type[FilterConfig]" = FilterConfig
+    strategy_config: "type[FilterConfig]" = FilterConfig

--- a/otelib/backends/python/function.py
+++ b/otelib/backends/python/function.py
@@ -1,12 +1,7 @@
 """Function strategy."""
-from typing import TYPE_CHECKING
-
 from oteapi.models import FunctionConfig
 
 from otelib.backends.python.base import BasePythonStrategy
-
-if TYPE_CHECKING:  # pragma: no cover
-    from typing import Type
 
 
 class Function(BasePythonStrategy):
@@ -14,4 +9,4 @@ class Function(BasePythonStrategy):
     operations."""
 
     strategy_name = "function"
-    strategy_config: "Type[FunctionConfig]" = FunctionConfig
+    strategy_config: "type[FunctionConfig]" = FunctionConfig

--- a/otelib/backends/python/mapping.py
+++ b/otelib/backends/python/mapping.py
@@ -1,12 +1,7 @@
 """Mapping strategy."""
-from typing import TYPE_CHECKING
-
 from oteapi.models import MappingConfig
 
 from otelib.backends.python.base import BasePythonStrategy
-
-if TYPE_CHECKING:  # pragma: no cover
-    from typing import Type
 
 
 class Mapping(BasePythonStrategy):
@@ -14,4 +9,4 @@ class Mapping(BasePythonStrategy):
     operations."""
 
     strategy_name = "mapping"
-    strategy_config: "Type[MappingConfig]" = MappingConfig
+    strategy_config: "type[MappingConfig]" = MappingConfig

--- a/otelib/backends/python/transformation.py
+++ b/otelib/backends/python/transformation.py
@@ -1,12 +1,7 @@
 """Transformation strategy."""
-from typing import TYPE_CHECKING
-
 from oteapi.models import TransformationConfig
 
 from otelib.backends.python.base import BasePythonStrategy
-
-if TYPE_CHECKING:  # pragma: no cover
-    from typing import Type
 
 
 class Transformation(BasePythonStrategy):
@@ -14,4 +9,4 @@ class Transformation(BasePythonStrategy):
     operations."""
 
     strategy_name = "transformation"
-    strategy_config: "Type[TransformationConfig]" = TransformationConfig
+    strategy_config: "type[TransformationConfig]" = TransformationConfig

--- a/otelib/backends/services/base.py
+++ b/otelib/backends/services/base.py
@@ -9,7 +9,7 @@ from otelib.exceptions import ApiError
 from otelib.settings import Settings
 
 if TYPE_CHECKING:  # pragma: no cover
-    from typing import Any, Dict, Optional
+    from typing import Any, Optional
 
 
 class BaseServicesStrategy(AbstractBaseStrategy):
@@ -29,11 +29,11 @@ class BaseServicesStrategy(AbstractBaseStrategy):
         super().__init__(source)
 
         self.url: "Optional[str]" = source
-        self._headers: "Optional[Dict[str, Any]]" = None
+        self._headers: "Optional[dict[str, Any]]" = None
         self.settings = Settings()
 
     @property
-    def headers(self) -> "Dict[str, Any]":
+    def headers(self) -> "dict[str, Any]":
         """URL headers to use for all requests to the OTEAPI Service."""
         value = self._headers or {}
         if "Content-Type" not in value:
@@ -41,7 +41,7 @@ class BaseServicesStrategy(AbstractBaseStrategy):
         return value
 
     @headers.setter
-    def headers(self, value: "Dict[str, Any]") -> None:
+    def headers(self, value: "dict[str, Any]") -> None:
         """Set the URL headers to use for all requests to the OTEAPI Service."""
         if not isinstance(value, dict):
             raise TypeError("headers must be a dictionary")
@@ -53,7 +53,7 @@ class BaseServicesStrategy(AbstractBaseStrategy):
 
         response = requests.post(
             f"{self.url}{self.settings.prefix}/{self.strategy_name}",
-            data=data.json(),
+            data=data.model_dump_json(),
             params={"session_id": session_id} if session_id else {},
             timeout=self.settings.timeout,
             headers=self.headers,

--- a/otelib/backends/services/client.py
+++ b/otelib/backends/services/client.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 from otelib.backends.client import AbstractBaseClient
 
 if TYPE_CHECKING:  # pragma: no cover
-    from typing import Any, Dict, Type
+    from typing import Any
 
     from otelib.backends.services.base import BaseServicesStrategy
 
@@ -21,7 +21,7 @@ class OTEServiceClient(AbstractBaseClient):
     _backend = "services"
 
     # config
-    _headers: "Dict[str, Any]" = {}
+    _headers: "dict[str, Any]" = {}
 
     @property
     def url(self) -> str:
@@ -29,7 +29,7 @@ class OTEServiceClient(AbstractBaseClient):
         return self.source
 
     def _create_strategy(  # type: ignore[override]
-        self, strategy_cls: "Type[BaseServicesStrategy]", **config
+        self, strategy_cls: "type[BaseServicesStrategy]", **config
     ) -> "BaseServicesStrategy":
         strategy = strategy_cls(self.url)
         strategy.headers = self.headers
@@ -37,7 +37,7 @@ class OTEServiceClient(AbstractBaseClient):
         return strategy
 
     @property
-    def headers(self) -> "Dict[str, Any]":
+    def headers(self) -> "dict[str, Any]":
         """URL headers to use for all requests to the OTEAPI Service."""
         value = self._headers
         if "Content-Type" not in value:
@@ -45,12 +45,12 @@ class OTEServiceClient(AbstractBaseClient):
         return value
 
     @headers.setter
-    def headers(self, value: "Dict[str, Any]") -> None:
+    def headers(self, value: "dict[str, Any]") -> None:
         """Set the URL headers to use for all requests to the OTEAPI Service."""
         if not isinstance(value, dict):
             raise TypeError("headers must be a dictionary")
         self._headers = value
 
-    def _set_config(self, config: "Dict[str, Any]") -> None:
+    def _set_config(self, config: "dict[str, Any]") -> None:
         self.headers = config.pop("headers", {})
         return super()._set_config(config)

--- a/otelib/backends/strategies.py
+++ b/otelib/backends/strategies.py
@@ -7,7 +7,7 @@ from otelib.backends.utils import StrategyType
 from otelib.pipe import Pipe
 
 if TYPE_CHECKING:  # pragma: no cover
-    from typing import Optional, Type, Union
+    from typing import Optional, Union
 
     from oteapi.models.genericconfig import GenericConfig
 
@@ -16,7 +16,7 @@ class AbstractBaseStrategy(ABC):
     """The abstract base class defining the API for strategies."""
 
     strategy_name: "Union[StrategyType, str]"
-    strategy_config: "Type[GenericConfig]"
+    strategy_config: "type[GenericConfig]"
 
     def __init__(self, source: str) -> None:
         """Initiates a strategy."""

--- a/otelib/client.py
+++ b/otelib/client.py
@@ -1,7 +1,7 @@
 """OTE Client."""
 from typing import TYPE_CHECKING
 
-from pydantic import AnyHttpUrl, ValidationError, parse_obj_as
+from pydantic import AnyHttpUrl, ValidationError
 
 from otelib.backends.factories import client_factory
 from otelib.backends.utils import Backend, StrategyType
@@ -31,7 +31,7 @@ class OTEClient:
 
         """
         try:
-            parse_obj_as(AnyHttpUrl, url)
+            AnyHttpUrl(url)
         except ValidationError:
             backend = Backend.PYTHON
         else:

--- a/otelib/settings.py
+++ b/otelib/settings.py
@@ -1,16 +1,18 @@
 """Configuration settings for creating the OTE client."""
-from pydantic import BaseModel, Field
+from typing import Annotated
+
+from pydantic import Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
-class Settings(BaseModel):
+class Settings(BaseSettings):
     """Configuration settings for an OTE client."""
 
-    prefix: str = Field("/api/v1", description="Application route prefix.")
-    timeout: tuple[float, float] = Field(
-        (3.0, 27.0), description="Tuple for URL connect and read timeouts in seconds."
-    )
+    model_config = SettingsConfigDict(env_prefix="OTEAPI_")
 
-    class Config:
-        """Pydantic configuration class."""
+    prefix: Annotated[str, Field(description="Application route prefix.")] = "/api/v1"
 
-        env_prefix = "OTEAPI_"
+    timeout: Annotated[
+        tuple[float, float],
+        Field(description="Tuple for URL connect and read timeouts in seconds."),
+    ] = (3.0, 27.0)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,8 @@ requires-python = "~=3.9"
 dynamic = ["version"]
 
 dependencies = [
-    "oteapi-core >=0.5.2,<0.6",
-    "pydantic <2",
+    "oteapi-core >=0.6.0,<1",
+    "pydantic-settings ~=2.0",
 ]
 
 [project.optional-dependencies]
@@ -68,6 +68,6 @@ disable = [
 minversion = "7.0"
 addopts = "-rs --cov=otelib --cov-report=term --durations=10"
 filterwarnings = [
-    "ignore:.*imp module.*:DeprecationWarning",
+    "ignore:.*No global cache used.*:UserWarning",
 ]
 requests_mock_case_sensitive = true

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,16 +14,32 @@ if TYPE_CHECKING:
     from otelib.client import OTEClient
 
     class TestResourceIds(Protocol):
-        """Return a test id for the given `resource_type`."""
+        """Defines a protocol for fetching a test ID based on the provided resource
+        type."""
 
         def __call__(self, resource_type: Union[ResourceType, str]) -> str:
             ...
 
     class OTEResponse(Protocol):
-        """Use `requests_mock` to mock a response from an OTE services server.
+        """Defines a protocol for mocking a response from an OTE services server using
+        `requests_mock`.
 
-        It will only be ensured that the `endpoint` starts with a forward slash.
-        If it does not, one will be added. Otherwise, `endpoint` is not manipulated.
+        The implementing callable should ensure that the `endpoint` starts with a
+        forward slash (`/`). If it doesn't, one is added. No other manipulation on the
+        `endpoint` is done.
+
+        Parameters:
+            method: The HTTP method (or its string representation) for the request.
+            endpoint: The API endpoint. Should start with a forward slash.
+            status_code: The desired HTTP status code for the response. Defaults to 200
+                (OK).
+            params: Optional request parameters.
+            headers: Optional request headers.
+            response_content: Optional content to be returned as the response body.
+            response_json: Optional JSON data to be returned as the response body.
+            response_text: Optional plain text to be returned as the response body.
+            ote_client: An optional client instance for making the request.
+
         """
 
         def __call__(
@@ -33,20 +49,25 @@ if TYPE_CHECKING:
             status_code: int = 200,
             params: Optional[Union[dict[str, Any], str]] = None,
             headers: Optional[dict] = None,
-            return_content: Optional[bytes] = None,
-            return_json: Optional[Union[dict, str]] = None,
-            return_text: Optional[str] = None,
+            response_content: Optional[bytes] = None,
+            response_json: Optional[Union[dict, str]] = None,
+            response_text: Optional[str] = None,
             ote_client: Optional[OTEClient] = None,
         ) -> None:
             ...
 
     class Testdata(Protocol):
-        """Return test data for a given resource.
+        """Defines a protocol for fetching test data corresponding to a specified
+        resource type.
+
+        Test data can be optionally tailored based on a provided method (e.g., "get",
+        "initialize"). If no method is specified, the test data is provided in its
+        default form.
 
         Parameters:
             resource_type: The resource type to return test data for.
-            method: Optionally, provide the method for which to return the test data.
-                If not given, the test data will be provided as is.
+            method: An optional method specifier which can influence the structure of
+                the returned test data.
 
         """
 
@@ -179,9 +200,9 @@ def mock_ote_response(requests_mock: "Mocker", server_url: str) -> "OTEResponse"
         status_code: int = 200,
         params: "Optional[Union[dict[str, Any], str]]" = None,
         headers: "Optional[dict]" = None,
-        return_content: "Optional[bytes]" = None,
-        return_json: "Optional[Union[dict, str]]" = None,
-        return_text: "Optional[str]" = None,
+        response_content: "Optional[bytes]" = None,
+        response_json: "Optional[Union[dict, str]]" = None,
+        response_text: "Optional[str]" = None,
         ote_client: "Optional[OTEClient]" = None,
     ) -> None:
         """Use `requests_mock` to mock a response from an OTE services server.
@@ -229,12 +250,12 @@ def mock_ote_response(requests_mock: "Mocker", server_url: str) -> "OTEResponse"
             params = ""
 
         mock_kwargs = {}
-        if return_content is not None:
-            mock_kwargs["content"] = return_content
-        if return_json is not None:
-            mock_kwargs["json"] = return_json
-        if return_text is not None:
-            mock_kwargs["text"] = return_text
+        if response_content is not None:
+            mock_kwargs["content"] = response_content
+        if response_json is not None:
+            mock_kwargs["json"] = response_json
+        if response_text is not None:
+            mock_kwargs["text"] = response_text
         if headers is not None:
             mock_kwargs["headers"] = headers
 

--- a/tests/strategies/conftest.py
+++ b/tests/strategies/conftest.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 if TYPE_CHECKING:
-    from typing import Literal, Tuple, Type, Union
+    from typing import Literal, Union
 
     from otelib.backends import python as python_backend
     from otelib.backends import services as services_backend
@@ -31,8 +31,8 @@ if TYPE_CHECKING:
 def strategy_implementation(
     request: pytest.FixtureRequest,
     backend: str,
-    resource_type_cls: "Type[ResourceType]",
-) -> "Tuple[Type[StrategyCls], ResourceType, Literal['python', 'services']]":
+    resource_type_cls: "type[ResourceType]",
+) -> "tuple[type[StrategyCls], ResourceType, Literal['python', 'services']]":
     """Return a given strategy class implementation as well as the current backend.
 
     Returns:

--- a/tests/strategies/test_abc.py
+++ b/tests/strategies/test_abc.py
@@ -53,7 +53,7 @@ def test_get(
         mock_ote_response(
             method="post",
             endpoint=f"/{strategy_name}",
-            return_json={
+            response_json={
                 f"{strategy_name[len('data'):] if strategy_name.startswith('data') else strategy_name}"  # pylint: disable=line-too-long
                 "_id": ids(strategy_name)
             },
@@ -65,7 +65,7 @@ def test_get(
             method="post",
             endpoint=f"/{strategy_name}/{ids(strategy_name)}/initialize",
             params={"session_id": ids("session")},
-            return_json=(
+            response_json=(
                 testdata(strategy_name)
                 if strategy_name in ("filter", "mapping")
                 else {}
@@ -79,7 +79,7 @@ def test_get(
             method="get",
             endpoint=f"/{strategy_name}/{ids(strategy_name)}",
             params={"session_id": ids("session")},
-            return_json=(
+            response_json=(
                 testdata(strategy_name)
                 if strategy_name in ("dataresource", "transformation")
                 else {}
@@ -90,7 +90,7 @@ def test_get(
         mock_ote_response(
             method="get",
             endpoint=f"/session/{ids('session')}",
-            return_json=testdata(strategy_name),
+            response_json=testdata(strategy_name),
         )
 
     if backend == "python" and strategy_name == "dataresource":
@@ -193,7 +193,7 @@ def test_services_get_fails(
     mock_ote_response(
         method="post",
         endpoint=f"/{strategy_name}",
-        return_json={
+        response_json={
             f"{strategy_name[len('data'):] if strategy_name.startswith('data') else strategy_name}"  # pylint: disable=line-too-long
             "_id": ids(strategy_name)
         },

--- a/tests/strategies/test_abc.py
+++ b/tests/strategies/test_abc.py
@@ -6,14 +6,14 @@ import pytest
 from utils import strategy_create_kwargs
 
 if TYPE_CHECKING:
-    from typing import Any, Callable, Dict, Union
+    from typing import Any, Union
 
     from requests_mock import Mocker
 
     from otelib.backends.python.base import BasePythonStrategy
     from otelib.backends.services.base import BaseServicesStrategy
 
-    from ..conftest import OTEResponse, ResourceType
+    from ..conftest import OTEResponse, Testdata, TestResourceIds
 
     BaseStrategy = Union[BasePythonStrategy, BaseServicesStrategy]
 
@@ -27,11 +27,11 @@ if TYPE_CHECKING:
 def test_get(
     backend: str,
     mock_ote_response: "OTEResponse",
-    ids: "Callable[[Union[ResourceType, str]], str]",
-    testdata: "Callable[[Union[ResourceType, str]], dict]",
+    ids: "TestResourceIds",
+    testdata: "Testdata",
     server_url: str,
     strategy_name: str,
-    create_kwargs: "Dict[str, Any]",
+    create_kwargs: "dict[str, Any]",
     requests_mock: "Mocker",
 ) -> None:
     """Test `AbstractStrategy.get()`."""
@@ -143,7 +143,7 @@ def test_get(
             f"{strategy.url}{strategy.settings.prefix}/session/{strategy._session_id}",
             timeout=30,
         )
-        session: "Dict[str, Any]" = content_session.json()
+        session: "dict[str, Any]" = content_session.json()
     elif backend == "python":
         session_ids = [x for x in strategy.cache if "session" in x]
         assert len(session_ids) == 1
@@ -176,10 +176,10 @@ def test_get(
 )
 def test_services_get_fails(
     mock_ote_response: "OTEResponse",
-    ids: "Callable[[Union[ResourceType, str]], str]",
+    ids: "TestResourceIds",
     server_url: str,
     strategy_name: str,
-    create_kwargs: "Dict[str, Any]",
+    create_kwargs: "dict[str, Any]",
     requests_mock: "Mocker",
 ) -> None:
     """Check `AbstractStrategy.get()` raises `ApiError` upon request failure."""

--- a/tests/strategies/test_all_strategies.py
+++ b/tests/strategies/test_all_strategies.py
@@ -30,7 +30,7 @@ def test_create(
         mock_ote_response(
             method="post",
             endpoint=f"/{strategy_type.value}",
-            return_json={strategy_type.get_return_id_key(): ids(strategy_type.value)},
+            response_json={strategy_type.get_return_id_key(): ids(strategy_type.value)},
         )
 
     strategy = strategy_cls(server_url)
@@ -66,7 +66,7 @@ def test_create_fails(
             method="post",
             endpoint=f"/{strategy_type.value}",
             status_code=500,
-            return_content=b"Internal Server Error",
+            response_content=b"Internal Server Error",
         )
 
     strategy = strategy_cls(server_url)
@@ -107,13 +107,13 @@ def test_fetch(
         mock_ote_response(
             method="post",
             endpoint=f"/{strategy_type.value}",
-            return_json={strategy_type.get_return_id_key(): ids(strategy_type.value)},
+            response_json={strategy_type.get_return_id_key(): ids(strategy_type.value)},
         )
 
         mock_ote_response(
             method="get",
             endpoint=f"/{strategy_type.value}/{ids(strategy_type.value)}",
-            return_json=testdata(strategy_type, "get"),
+            response_json=testdata(strategy_type, "get"),
         )
 
     strategy = strategy_cls(server_url)
@@ -175,14 +175,14 @@ def test_fetch_fails(
         mock_ote_response(
             method="post",
             endpoint=f"/{strategy_type.value}",
-            return_json={strategy_type.get_return_id_key(): ids(strategy_type.value)},
+            response_json={strategy_type.get_return_id_key(): ids(strategy_type.value)},
         )
 
         mock_ote_response(
             method="get",
             endpoint=f"/{strategy_type.value}/{ids(strategy_type.value)}",
             status_code=500,
-            return_content=b"Internal Server Error",
+            response_content=b"Internal Server Error",
         )
 
     strategy = strategy_cls(server_url)
@@ -220,13 +220,13 @@ def test_initialize(
         mock_ote_response(
             method="post",
             endpoint=f"/{strategy_type.value}",
-            return_json={strategy_type.get_return_id_key(): ids(strategy_type.value)},
+            response_json={strategy_type.get_return_id_key(): ids(strategy_type.value)},
         )
 
         mock_ote_response(
             method="post",
             endpoint=f"/{strategy_type.value}/{ids(strategy_type.value)}/initialize",
-            return_json=testdata(strategy_type, "initialize"),
+            response_json=testdata(strategy_type, "initialize"),
         )
 
     strategy = strategy_cls(server_url)
@@ -277,14 +277,14 @@ def test_initialize_fails(
         mock_ote_response(
             method="post",
             endpoint=f"/{strategy_type.value}",
-            return_json={strategy_type.get_return_id_key(): ids(strategy_type.value)},
+            response_json={strategy_type.get_return_id_key(): ids(strategy_type.value)},
         )
 
         mock_ote_response(
             method="post",
             endpoint=f"/{strategy_type.value}/{ids(strategy_type.value)}/initialize",
             status_code=500,
-            return_content=b"Internal Server Error",
+            response_content=b"Internal Server Error",
         )
 
     strategy = strategy_cls(server_url)

--- a/tests/strategies/test_all_strategies.py
+++ b/tests/strategies/test_all_strategies.py
@@ -5,19 +5,18 @@ from typing import TYPE_CHECKING
 import pytest
 
 if TYPE_CHECKING:
-    from typing import Any, Callable, Tuple, Type, Union
+    from typing import Any
 
     from requests_mock import Mocker
-    from utils import ResourceType
 
-    from ..conftest import OTEResponse
+    from ..conftest import OTEResponse, ResourceType, Testdata, TestResourceIds
     from .conftest import StrategyCls
 
 
 def test_create(
-    strategy_implementation: "Tuple[Type[StrategyCls], ResourceType, str]",
+    strategy_implementation: "tuple[type[StrategyCls], ResourceType, str]",
     mock_ote_response: "OTEResponse",
-    ids: "Callable[[Union[ResourceType, str]], str]",
+    ids: "TestResourceIds",
     server_url: str,
 ) -> None:
     """Test the `create()` method."""
@@ -44,7 +43,7 @@ def test_create(
 
 
 def test_create_fails(
-    strategy_implementation: "Tuple[Type[StrategyCls], ResourceType, str]",
+    strategy_implementation: "tuple[type[StrategyCls], ResourceType, str]",
     mock_ote_response: "OTEResponse",
     server_url: str,
 ) -> None:
@@ -83,11 +82,11 @@ def test_create_fails(
 
 
 def test_fetch(
-    strategy_implementation: "Tuple[Type[StrategyCls], ResourceType, str]",
+    strategy_implementation: "tuple[type[StrategyCls], ResourceType, str]",
     mock_ote_response: "OTEResponse",
-    ids: "Callable[[Union[ResourceType, str]], str]",
+    ids: "TestResourceIds",
     server_url: str,
-    testdata: "Callable[[Union[ResourceType, str]], dict]",
+    testdata: "Testdata",
     requests_mock: "Mocker",
 ) -> None:
     """Test the `fetch()` method."""
@@ -154,9 +153,9 @@ def test_fetch(
 
 
 def test_fetch_fails(
-    strategy_implementation: "Tuple[Type[StrategyCls], ResourceType, str]",
+    strategy_implementation: "tuple[type[StrategyCls], ResourceType, str]",
     mock_ote_response: "OTEResponse",
-    ids: "Callable[[Union[ResourceType, str]], str]",
+    ids: "TestResourceIds",
     server_url: str,
 ) -> None:
     """Check `fetch()` raises `ApiError` upon request failure."""
@@ -197,11 +196,11 @@ def test_fetch_fails(
 
 
 def test_initialize(
-    strategy_implementation: "Tuple[Type[StrategyCls], ResourceType, str]",
+    strategy_implementation: "tuple[type[StrategyCls], ResourceType, str]",
     mock_ote_response: "OTEResponse",
-    ids: "Callable[[Union[ResourceType, str]], str]",
+    ids: "TestResourceIds",
     server_url: str,
-    testdata: "Callable[[Union[ResourceType, str]], dict]",
+    testdata: "Testdata",
 ) -> None:
     """Test `DataResource.initialize()`."""
     import json
@@ -255,9 +254,9 @@ def test_initialize(
 
 
 def test_initialize_fails(
-    strategy_implementation: "Tuple[Type[StrategyCls], ResourceType, str]",
+    strategy_implementation: "tuple[type[StrategyCls], ResourceType, str]",
     mock_ote_response: "OTEResponse",
-    ids: "Callable[[Union[ResourceType, str]], str]",
+    ids: "TestResourceIds",
     server_url: str,
 ) -> None:
     """Check `DataResource.initialize()` raises `ApiError` upon request failure."""

--- a/tests/test_oteclient.py
+++ b/tests/test_oteclient.py
@@ -55,7 +55,7 @@ def test_create_strategies(
         mock_ote_response(
             method="post",
             endpoint=f"/{strategy}",
-            return_json={
+            response_json={
                 f"{strategy[len('data'):] if strategy.startswith('data') else strategy}"
                 "_id": ids(strategy)
             },
@@ -67,7 +67,7 @@ def test_create_strategies(
             method="post",
             endpoint=f"/{strategy}/{ids(strategy)}/initialize",
             params={"session_id": ids("session")},
-            return_json=(
+            response_json=(
                 testdata(strategy) if strategy in ("filter", "mapping") else {}
             ),
         )
@@ -79,7 +79,7 @@ def test_create_strategies(
             method="get",
             endpoint=f"/{strategy}/{ids(strategy)}",
             params={"session_id": ids("session")},
-            return_json=(
+            response_json=(
                 testdata(strategy)
                 if strategy in ("dataresource", "transformation")
                 else {}
@@ -90,7 +90,7 @@ def test_create_strategies(
         mock_ote_response(
             method="get",
             endpoint=f"/session/{ids('session')}",
-            return_json=testdata(strategy),
+            response_json=testdata(strategy),
         )
 
     if backend == "python" and strategy == "dataresource":

--- a/tests/test_oteclient.py
+++ b/tests/test_oteclient.py
@@ -7,7 +7,7 @@ import pytest
 from utils import strategy_create_kwargs
 
 if TYPE_CHECKING:
-    from typing import Any, Callable, Dict, Union
+    from typing import Any, Union
 
     from requests_mock import Mocker
 
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     from otelib.backends.services.base import BaseServicesStrategy
     from otelib.client import OTEClient
 
-    from .conftest import OTEResponse, ResourceType
+    from .conftest import OTEResponse, Testdata, TestResourceIds
 
     BaseStrategy = Union[BasePythonStrategy, BaseServicesStrategy]
 
@@ -28,11 +28,11 @@ if TYPE_CHECKING:
 @pytest.mark.usefixtures("mock_session")
 def test_create_strategies(
     client: "OTEClient",
-    ids: "Callable[[Union[ResourceType, str]], str]",
+    ids: "TestResourceIds",
     mock_ote_response: "OTEResponse",
-    testdata: "Callable[[Union[ResourceType, str]], dict]",
+    testdata: "Testdata",
     strategy: str,
-    create_kwargs: "Dict[str, Any]",
+    create_kwargs: "dict[str, Any]",
     requests_mock: "Mocker",
 ) -> None:
     """Test creating any strategy and calling it's `get()` method."""
@@ -135,7 +135,7 @@ def test_create_strategies(
             f"{created_strategy.url}{strategy_prefix}/session/{startegy_sessionid}",
             timeout=30,
         )
-        session: "Dict[str, Any]" = content_session.json()
+        session: "dict[str, Any]" = content_session.json()
 
     elif backend == "python":
         session_ids = [

--- a/tests/test_pipe.py
+++ b/tests/test_pipe.py
@@ -7,7 +7,7 @@ import pytest
 from utils import strategy_create_kwargs
 
 if TYPE_CHECKING:
-    from typing import Any, Callable, Dict, Union
+    from typing import Any, Union
 
     from requests_mock import Mocker
 
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
     from otelib.backends.python.base import BasePythonStrategy
     from otelib.backends.services.base import BaseServicesStrategy
 
-    from .conftest import OTEResponse, ResourceType
+    from .conftest import OTEResponse, Testdata, TestResourceIds
 
     BaseStrategy = Union[BasePythonStrategy, BaseServicesStrategy]
 
@@ -33,11 +33,11 @@ if TYPE_CHECKING:
 def test_pipe(
     backend: str,
     mock_ote_response: "OTEResponse",
-    ids: "Callable[[Union[ResourceType, str]], str]",
-    testdata: "Callable[[Union[ResourceType, str]], dict]",
+    ids: "TestResourceIds",
+    testdata: "Testdata",
     server_url: str,
     strategy_name: str,
-    create_kwargs: "Dict[str, Any]",
+    create_kwargs: "dict[str, Any]",
     requests_mock: "Mocker",
 ) -> None:
     """Test creating a `Pipe` and run the `get()` method."""
@@ -148,7 +148,7 @@ def test_pipe(
             f"{strategy.url}{strategy.settings.prefix}/session/{strategy._session_id}",
             timeout=30,
         )
-        session: "Dict[str, Any]" = content_session.json()
+        session: "dict[str, Any]" = content_session.json()
     elif backend == "python":
         session_ids = [x for x in strategy.cache if "session" in x]
         assert len(session_ids) == 1
@@ -177,8 +177,8 @@ def test_pipe(
 def test_pipeing_strategies(  # pylint: disable=too-many-statements
     backend: str,
     mock_ote_response: "OTEResponse",
-    ids: "Callable[[Union[ResourceType, str]], str]",
-    testdata: "Callable[[Union[ResourceType, str]], dict]",
+    ids: "TestResourceIds",
+    testdata: "Testdata",
     server_url: str,
     requests_mock: "Mocker",
 ) -> None:
@@ -289,7 +289,7 @@ def test_pipeing_strategies(  # pylint: disable=too-many-statements
             f"{pipeline.url}{pipeline.settings.prefix}/session/{pipeline._session_id}",
             timeout=30,
         )
-        session: "Dict[str, Any]" = content_session.json()
+        session: "dict[str, Any]" = content_session.json()
     elif backend == "python":
         session_ids = [x for x in pipeline.cache if "session" in x]
         assert len(session_ids) == 1
@@ -338,7 +338,7 @@ def test_pipeing_strategies(  # pylint: disable=too-many-statements
             f"{pipeline.url}{pipeline.settings.prefix}/session/{pipeline._session_id}",
             timeout=30,
         )
-        session: "Dict[str, Any]" = content_session.json()
+        session: "dict[str, Any]" = content_session.json()
     elif backend == "python":
         session_ids = [x for x in pipeline.cache if "session" in x]
         assert len(session_ids) == 1

--- a/tests/test_pipe.py
+++ b/tests/test_pipe.py
@@ -64,7 +64,7 @@ def test_pipe(
         mock_ote_response(
             method="post",
             endpoint=f"/{strategy_name}",
-            return_json={
+            response_json={
                 f"{strategy_name[len('data'):] if strategy_name.startswith('data') else strategy_name}"  # pylint: disable=line-too-long
                 "_id": ids(strategy_name)
             },
@@ -76,7 +76,7 @@ def test_pipe(
             method="post",
             endpoint=f"/{strategy_name}/{ids(strategy_name)}/initialize",
             params={"session_id": ids("session")},
-            return_json=(
+            response_json=(
                 testdata(strategy_name)
                 if strategy_name in ("filter", "mapping")
                 else {}
@@ -90,7 +90,7 @@ def test_pipe(
             method="get",
             endpoint=f"/{strategy_name}/{ids(strategy_name)}",
             params={"session_id": ids("session")},
-            return_json=(
+            response_json=(
                 testdata(strategy_name)
                 if strategy_name in ("dataresource", "transformation")
                 else {}
@@ -101,7 +101,7 @@ def test_pipe(
         mock_ote_response(
             method="get",
             endpoint=f"/session/{ids('session')}",
-            return_json=testdata(strategy_name),
+            response_json=testdata(strategy_name),
         )
 
     if backend == "python" and strategy_name == "dataresource":
@@ -201,12 +201,12 @@ def test_pipeing_strategies(  # pylint: disable=too-many-statements
         mock_ote_response(
             method="post",
             endpoint="/dataresource",
-            return_json={"resource_id": ids("dataresource")},
+            response_json={"resource_id": ids("dataresource")},
         )
         mock_ote_response(
             method="post",
             endpoint="/filter",
-            return_json={"filter_id": ids("filter")},
+            response_json={"filter_id": ids("filter")},
         )
 
         # initialize()
@@ -214,13 +214,13 @@ def test_pipeing_strategies(  # pylint: disable=too-many-statements
             method="post",
             endpoint=f"/dataresource/{ids('dataresource')}/initialize",
             params={"session_id": ids("session")},
-            return_json={},
+            response_json={},
         )
         mock_ote_response(
             method="post",
             endpoint=f"/filter/{ids('filter')}/initialize",
             params={"session_id": ids("session")},
-            return_json=testdata("filter"),
+            response_json=testdata("filter"),
         )
 
         # fetch()
@@ -228,20 +228,20 @@ def test_pipeing_strategies(  # pylint: disable=too-many-statements
             method="get",
             endpoint=f"/dataresource/{ids('dataresource')}",
             params={"session_id": ids("session")},
-            return_json=testdata("dataresource"),
+            response_json=testdata("dataresource"),
         )
         mock_ote_response(
             method="get",
             endpoint=f"/filter/{ids('filter')}",
             params={"session_id": ids("session")},
-            return_json={},
+            response_json={},
         )
 
         # Session content
         mock_ote_response(
             method="get",
             endpoint=f"/session/{ids('session')}",
-            return_json=session_test_content,
+            response_json=session_test_content,
         )
 
     if backend == "python":

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -3,7 +3,7 @@ from enum import Enum
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Any, Dict, List, Literal, Tuple
+    from typing import Any, Literal
 
 
 TEST_DATA = {
@@ -82,7 +82,7 @@ class ResourceType(str, Enum):
             ) from exc
 
 
-def strategy_create_kwargs() -> "List[Tuple[str, Dict[str, Any]]]":
+def strategy_create_kwargs() -> "list[tuple[str, dict[str, Any]]]":
     """Strategy to creation key-word-arguments."""
     return [
         (


### PR DESCRIPTION
# Description:
<!-- Summary of change, including the issue to be addressed. -->
Closes #129 

Update minimum OTEAPI Core dependency to ~v0.5.1~ v0.6.0, which is the first version to add support for pydantic v2.
Update pre-commit hook dependencies to pydantic v2.
Depend on `pydantic-settings`, because all things `BaseSettings` have been moved there.

Indeed, `BaseSettings` was in fact _not_ used as the parent class for `otelib.settings.Settings`, which is a bug. This has now been remedied.
Furthermore, `AnyHttpUrl` can now be instantiated manually, so no need to use the (now deprecated) `parse_obj_as()` function.

This migration was done via [`bump-pydantic`](https://github.com/pydantic/bump-pydantic) and some manual rejigging.
As there aren't many things "pydantic" in this repository, this migration is really straight forward and minimal.

---

Updates:
- Using `typing.Annotated` where possible as recommended by pydantic, when using v2.
- Updating to Python 3.9 typing style, as this is the minimum supported Python version.
- Implement nice Protocol classes for callable pytest fixtures to have keyword-parameter support in IDEs.

## Type of change:
<!-- Put an `x` in the box that applies. -->
- [ ] Bug fix.
- [ ] New feature.
- [ ] Documentation update.

## Checklist for the reviewer:
<!-- Put an `x` in the boxes that apply. These can be filled by reviewer after the PR is created. -->

This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
