### PR TITLE
Have all strategy response types be AttrDict (not bytes)

### DIFF
--- a/docs/demo-notebooks/execute.ipynb
+++ b/docs/demo-notebooks/execute.ipynb
@@ -10,8 +10,6 @@
     "%load_ext autoreload\n",
     "%autoreload 2\n",
     "\n",
-    "import json\n",
-    "\n",
     "from otelib import OTEClient\n",
     "\n",
     "URL = \"http://localhost:8080\"\n",
@@ -36,11 +34,10 @@
     "print(data_resource)\n",
     "print(data_resource.strategy_id)\n",
     "\n",
-    "get_raw = data_resource.get()\n",
-    "print(get_raw)\n",
+    "result = data_resource.get()\n",
+    "print(result)\n",
     "\n",
     "# Before cropping to 400 x 200\n",
-    "result: dict = json.loads(get_raw)\n",
     "assert result.get(\"image_size\", []) != [400, 200]"
    ]
   },
@@ -70,10 +67,9 @@
    "source": [
     "pipeline = data_filter >> data_resource  \n",
     "\n",
-    "result_raw = pipeline.get()\n",
-    "print(result_raw)\n",
+    "result = pipeline.get()\n",
+    "print(result)\n",
     "\n",
-    "result: dict = json.loads(result_raw)\n",
     "assert result.get(\"image_size\", []) == [400, 200]"
    ]
   }
@@ -94,7 +90,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.12"
+   "version": "3.9.10"
   },
   "vscode": {
    "interpreter": {

--- a/otelib/backends/python/base.py
+++ b/otelib/backends/python/base.py
@@ -13,7 +13,7 @@ from otelib.exceptions import ItemNotFoundInCache, PythonBackendException
 if TYPE_CHECKING:  # pragma: no cover
     from typing import Any, Dict, Literal, Optional
 
-    from oteapi.models import SessionUpdate
+    from oteapi.models import AttrDict, SessionUpdate
 
 
 class BasePythonStrategy(AbstractBaseStrategy):
@@ -67,10 +67,10 @@ class BasePythonStrategy(AbstractBaseStrategy):
             else:
                 self.cache[session_id][list_key] = [self.strategy_id]
 
-    def fetch(self, session_id: str) -> bytes:
+    def fetch(self, session_id: str) -> "AttrDict":
         return self._run_strategy_method("get", session_id)
 
-    def initialize(self, session_id: str) -> bytes:
+    def initialize(self, session_id: str) -> "AttrDict":
         return self._run_strategy_method("initialize", session_id)
 
     def _create_session(self) -> str:
@@ -80,7 +80,7 @@ class BasePythonStrategy(AbstractBaseStrategy):
 
     def _run_strategy_method(
         self, method_name: "Literal['get', 'initialize']", session_id: str
-    ) -> bytes:
+    ) -> "SessionUpdate":
         """Generic implementation of the `fetch()` and `initialize()` methods.
 
         This will run the `method_name` method on the strategy and return the
@@ -91,7 +91,7 @@ class BasePythonStrategy(AbstractBaseStrategy):
             session_id: The ID of the session shared by the pipeline.
 
         Returns:
-            The bytes-serialized output from the given strategy method.
+            The dict-like pydantic model session output from the given strategy method.
 
         """
         if method_name not in ["get", "initialize"]:
@@ -115,7 +115,7 @@ class BasePythonStrategy(AbstractBaseStrategy):
 
         self.cache[session_id].update(session_update)
 
-        return session_update.json().encode(encoding="utf-8")
+        return session_update
 
     def _sanity_checks(self, session_id: str) -> None:
         """Perform sanity checks before running a strategy method.

--- a/otelib/backends/python/dataresource.py
+++ b/otelib/backends/python/dataresource.py
@@ -11,6 +11,8 @@ from otelib.backends.python.base import BasePythonStrategy
 if TYPE_CHECKING:  # pragma: no cover
     from typing import Type
 
+    from oteapi.models.sessionupdate import SessionUpdate
+
 
 class DataResource(BasePythonStrategy):
     """Context class for the data resource strategy interfaces for managing i/o
@@ -19,7 +21,7 @@ class DataResource(BasePythonStrategy):
     strategy_name = "dataresource"
     strategy_config: "Type[ResourceConfig]" = ResourceConfig
 
-    def fetch(self, session_id: str) -> bytes:
+    def fetch(self, session_id: str) -> "SessionUpdate":
         self._sanity_checks(session_id)
 
         config = self.strategy_config(**json.loads(self.cache[self.strategy_id]))
@@ -44,9 +46,9 @@ class DataResource(BasePythonStrategy):
             )
             self.cache[session_id].update(session_update)
 
-        return session_update.json().encode(encoding="utf-8")
+        return session_update
 
-    def initialize(self, session_id: str) -> bytes:
+    def initialize(self, session_id: str) -> "SessionUpdate":
         self._sanity_checks(session_id)
 
         config = self.strategy_config(**json.loads(self.cache[self.strategy_id]))
@@ -71,4 +73,4 @@ class DataResource(BasePythonStrategy):
             )
             self.cache[session_id].update(session_update)
 
-        return session_update.json().encode(encoding="utf-8")
+        return session_update

--- a/otelib/backends/services/base.py
+++ b/otelib/backends/services/base.py
@@ -1,8 +1,8 @@
 """Base class for strategies in the service/REST API backend."""
-import json
 from typing import TYPE_CHECKING
 
 import requests
+from oteapi.models import AttrDict
 
 from otelib.backends.strategies import AbstractBaseStrategy
 from otelib.exceptions import ApiError
@@ -72,7 +72,7 @@ class BaseServicesStrategy(AbstractBaseStrategy):
             else response_json.pop(f"{self.strategy_name[len('data'):]}_id")
         )
 
-    def fetch(self, session_id: str) -> bytes:
+    def fetch(self, session_id: str) -> AttrDict:
         response = requests.get(
             f"{self.url}{self.settings.prefix}/{self.strategy_name}/{self.strategy_id}",
             params={"session_id": session_id},
@@ -80,7 +80,7 @@ class BaseServicesStrategy(AbstractBaseStrategy):
             headers=self.headers,
         )
         if response.ok:
-            return response.content
+            return AttrDict(**response.json())
         strategy_name = (
             self.strategy_name[len("data") :]
             if self.strategy_name.startswith("data")
@@ -93,7 +93,7 @@ class BaseServicesStrategy(AbstractBaseStrategy):
             status=response.status_code,
         )
 
-    def initialize(self, session_id: str) -> bytes:
+    def initialize(self, session_id: str) -> AttrDict:
         post_path = (
             f"{self.url}{self.settings.prefix}"
             f"/{self.strategy_name}/{self.strategy_id}/initialize"
@@ -105,7 +105,7 @@ class BaseServicesStrategy(AbstractBaseStrategy):
             headers=self.headers,
         )
         if response.ok:
-            return response.content
+            return AttrDict(**response.json())
         strategy_name = (
             self.strategy_name[len("data") :]
             if self.strategy_name.startswith("data")
@@ -131,4 +131,4 @@ class BaseServicesStrategy(AbstractBaseStrategy):
                 f"{' content=' + str(response.content) if self.debug else ''}",
                 status=response.status_code,
             )
-        return json.loads(response.text)["session_id"]
+        return response.json()["session_id"]

--- a/otelib/backends/strategies.py
+++ b/otelib/backends/strategies.py
@@ -9,7 +9,7 @@ from otelib.pipe import Pipe
 if TYPE_CHECKING:  # pragma: no cover
     from typing import Optional, Type, Union
 
-    from oteapi.models.genericconfig import GenericConfig
+    from oteapi.models.genericconfig import AttrDict, GenericConfig
 
 
 class AbstractBaseStrategy(ABC):
@@ -39,7 +39,7 @@ class AbstractBaseStrategy(ABC):
         """
 
     @abstractmethod
-    def fetch(self, session_id: str) -> bytes:
+    def fetch(self, session_id: str) -> "AttrDict":
         """Returns the result of the current strategy.
 
         This method is called by `get()` while propagating up the pipeline.
@@ -53,7 +53,7 @@ class AbstractBaseStrategy(ABC):
         """
 
     @abstractmethod
-    def initialize(self, session_id: str) -> bytes:
+    def initialize(self, session_id: str) -> "AttrDict":
         """Initialise the current strategy.
 
         This method is called by `get()` when propagating down the pipeline.
@@ -66,7 +66,7 @@ class AbstractBaseStrategy(ABC):
 
         """
 
-    def get(self, session_id: "Optional[str]" = None) -> bytes:
+    def get(self, session_id: "Optional[str]" = None) -> "AttrDict":
         """Executes a pipeline.
 
         This will call `initialize()` and then the `get()` method on the

--- a/otelib/pipe.py
+++ b/otelib/pipe.py
@@ -4,6 +4,8 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:  # pragma: no cover
     from typing import Optional
 
+    from oteapi.models.genericconfig import AttrDict
+
     from otelib.backends.strategies import AbstractBaseStrategy
 
 
@@ -13,6 +15,6 @@ class Pipe:
     def __init__(self, strategy: "AbstractBaseStrategy") -> None:
         self.input: "AbstractBaseStrategy" = strategy
 
-    def get(self, session_id: "Optional[str]" = None) -> bytes:
+    def get(self, session_id: "Optional[str]" = None) -> "AttrDict":
         """Call the input strategy's `get()` method."""
         return self.input.get(session_id)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -138,9 +138,7 @@ def mock_session(
 
 
 @pytest.fixture
-def mock_ote_response(
-    requests_mock: "Mocker", server_url: str
-) -> "Callable[[Union[HTTPMethod, str], str, int, Optional[Union[Dict[str, Any], str]], Optional[dict], Optional[bytes], Optional[Union[dict, str]], Optional[str], Optional[OTEClient]], None]":  # pylint: disable=line-too-long
+def mock_ote_response(requests_mock: "Mocker", server_url: str) -> "OTEResponse":
     """Provide a function to mock OTE services responses."""
     from urllib.parse import parse_qs
 

--- a/tests/strategies/test_abc.py
+++ b/tests/strategies/test_abc.py
@@ -39,9 +39,9 @@ def test_get(
         pytest.skip("No function strategy exists in oteapi-core yet.")
 
     import importlib
-    import json
 
     import requests
+    from oteapi.models.genericconfig import AttrDict
 
     strategies = importlib.import_module(f"otelib.backends.{backend}")
     server_url = server_url if backend != "python" else backend
@@ -116,9 +116,9 @@ def test_get(
     assert strategy.strategy_name == strategy_name
 
     content = strategy.get()
-    assert isinstance(content, bytes)
+    assert isinstance(content, AttrDict)
     if strategy_name in ("filter", "mapping"):
-        assert json.loads(content) == {}
+        assert not content
     elif (
         strategy_name in ("transformation",)
         and backend == "services"
@@ -127,11 +127,10 @@ def test_get(
         # Real backend !
         # Dynamic response content - just check keys are the same and values are
         # non-empty
-        _content: "dict[str, Any]" = json.loads(content)
-        assert list(_content) == list(testdata(strategy_name))
-        assert all(_content.values())
+        assert list(content) == list(testdata(strategy_name))
+        assert all(content.values())
     else:
-        assert json.loads(content) == testdata(strategy_name)
+        assert content == testdata(strategy_name)
 
     ## The testdata should always be in the full session
     assert (

--- a/tests/strategies/test_all_strategies.py
+++ b/tests/strategies/test_all_strategies.py
@@ -91,8 +91,6 @@ def test_fetch(
     requests_mock: "Mocker",
 ) -> None:
     """Test the `fetch()` method."""
-    import json
-
     from utils import strategy_create_kwargs
 
     strategy_cls, strategy_type, backend = strategy_implementation
@@ -146,11 +144,10 @@ def test_fetch(
         # Real backend for transformation strategy
         # Dynamic response content - just check keys are the same and values are
         # non-empty
-        _content: "dict[str, Any]" = json.loads(content)
-        assert list(_content) == list(testdata(strategy_type, "get"))
-        assert all(_content.values())
+        assert list(content) == list(testdata(strategy_type, "get"))
+        assert all(content.values())
     else:
-        assert json.loads(content) == testdata(strategy_type, "get")
+        assert content == testdata(strategy_type, "get")
 
 
 def test_fetch_fails(
@@ -204,8 +201,6 @@ def test_initialize(
     testdata: "Callable[[Union[ResourceType, str]], dict]",
 ) -> None:
     """Test `DataResource.initialize()`."""
-    import json
-
     from utils import strategy_create_kwargs
 
     strategy_cls, strategy_type, backend = strategy_implementation
@@ -242,16 +237,15 @@ def test_initialize(
 
     content = strategy.initialize(session_id)
 
-    loaded_content = json.loads(content)
     testdata_strategy = testdata(strategy_type, "initialize")
     if strategy_type == strategy_type.MAPPING and (
         backend == "python" or "example" not in strategy.url
     ):
         # "triples" is a Set and must be "sorted"
-        loaded_content["triples"] = sorted(loaded_content["triples"])
+        content["triples"] = sorted(content["triples"])
         testdata_strategy["triples"] = sorted(testdata_strategy["triples"])
-
-    assert loaded_content == testdata_strategy
+    else:
+        assert content == testdata_strategy
 
 
 def test_initialize_fails(

--- a/tests/test_oteclient.py
+++ b/tests/test_oteclient.py
@@ -36,8 +36,6 @@ def test_create_strategies(
     requests_mock: "Mocker",
 ) -> None:
     """Test creating any strategy and calling it's `get()` method."""
-    import json
-
     import requests
 
     if strategy == "function":
@@ -108,7 +106,7 @@ def test_create_strategies(
 
     content = created_strategy.get()
     if strategy in ("filter", "mapping"):
-        assert json.loads(content) == {}
+        assert not content
     elif (
         strategy in ("transformation",)
         and client._impl._backend == "services"
@@ -117,11 +115,10 @@ def test_create_strategies(
         # Real backend !
         # Dynamic response content - just check keys are the same and values are
         # non-empty
-        _content: "dict[str, Any]" = json.loads(content)
-        assert list(_content) == list(testdata(strategy))
-        assert all(_content.values())
+        assert list(content) == list(testdata(strategy))
+        assert all(content.values())
     else:
-        assert json.loads(content) == testdata(strategy)
+        assert content == testdata(strategy)
 
     # The testdata should always be in the full session
     assert (

--- a/tests/test_pipe.py
+++ b/tests/test_pipe.py
@@ -48,7 +48,6 @@ def test_pipe(
             pytest.skip("No function strategy exists in oteapi-core yet.")
 
     import importlib
-    import json
 
     import requests
 
@@ -127,7 +126,7 @@ def test_pipe(
 
     content = pipe.get()
     if strategy_name in ("filter", "mapping"):
-        assert json.loads(content) == {}
+        assert not content
     elif (
         strategy_name in ("transformation",)
         and backend == "services"
@@ -136,11 +135,10 @@ def test_pipe(
         # Real backend !
         # Dynamic response content - just check keys are the same and values are
         # non-empty
-        _content: "dict[str, Any]" = json.loads(content)
-        assert list(_content) == list(testdata(strategy_name))
-        assert all(_content.values())
+        assert list(content) == list(testdata(strategy_name))
+        assert all(content.values())
     else:
-        assert json.loads(content) == testdata(strategy_name)
+        assert content == testdata(strategy_name)
 
     # The testdata should always be in the full session
     if backend == "services":
@@ -184,7 +182,6 @@ def test_pipeing_strategies(  # pylint: disable=too-many-statements
 ) -> None:
     """A simple pipeline will be tested."""
     import importlib
-    import json
 
     import requests
 
@@ -277,7 +274,7 @@ def test_pipeing_strategies(  # pylint: disable=too-many-statements
 
     # Since the "last" strategy does not return anything from its `get()` method,
     # this should return an empty dictionary.
-    assert json.loads(content) == {}
+    assert not content
 
     # All the test data should however be present in the session
     assert (
@@ -326,7 +323,7 @@ def test_pipeing_strategies(  # pylint: disable=too-many-statements
 
     # Since the "last" strategy now returns something from its `get()` method,
     # this can be tested.
-    assert json.loads(content) == testdata("dataresource")
+    assert content == testdata("dataresource")
 
     # All the test data should however be present in the session
     assert (


### PR DESCRIPTION
# Description:
<!-- Summary of change, including the issue to be addressed. -->
Closes #86 

By "all", is meant that all strategy methods that previously returned bytes, now return an oteapi.models.AttrDict.
It is equivalent to a MutableMapping, but is also a pydantic BaseModel.

The demo notebook, as well as all the unit tests, have also been updated accordingly.

## Type of change:
<!-- Put an `x` in the box that applies. -->
- [ ] Bug fix.
- [x] New feature.
- [ ] Documentation update.

## Checklist for the reviewer:
<!-- Put an `x` in the boxes that apply. These can be filled by reviewer after the PR is created. -->

This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
