### PR TITLE
Don't use filesamples.com

### DIFF
--- a/tests/static/sample.json
+++ b/tests/static/sample.json
@@ -1,0 +1,14 @@
+{
+    "firstName": "Joe",
+    "lastName": "Jackson",
+    "gender": "male",
+    "age": 28,
+    "address": {
+        "streetAddress": "101",
+        "city": "San Diego",
+        "state": "CA"
+    },
+    "phoneNumbers": [
+        { "type": "home", "number": "7349282382" }
+    ]
+}

--- a/tests/strategies/test_all_strategies.py
+++ b/tests/strategies/test_all_strategies.py
@@ -125,14 +125,7 @@ def test_fetch(
     # We must first create the resource - getting a resource ID
     strategy.create(**dict(strategy_create_kwargs())[strategy_type.value])
 
-    print("backend", backend)
-    print("strategy_type", strategy_type)
-    print("strategy_type.DATARESOURCE", strategy_type.DATARESOURCE)
     if backend == "python" and strategy_type == strategy_type.DATARESOURCE:
-        print(
-            "mocking URL:",
-            dict(strategy_create_kwargs())[strategy_type.value]["downloadUrl"],
-        )
         # Mock URL responses
         requests_mock.request(
             method="get",

--- a/tests/strategies/test_all_strategies.py
+++ b/tests/strategies/test_all_strategies.py
@@ -125,7 +125,14 @@ def test_fetch(
     # We must first create the resource - getting a resource ID
     strategy.create(**dict(strategy_create_kwargs())[strategy_type.value])
 
+    print("backend", backend)
+    print("strategy_type", strategy_type)
+    print("strategy_type.DATARESOURCE", strategy_type.DATARESOURCE)
     if backend == "python" and strategy_type == strategy_type.DATARESOURCE:
+        print(
+            "mocking URL:",
+            dict(strategy_create_kwargs())[strategy_type.value]["downloadUrl"],
+        )
         # Mock URL responses
         requests_mock.request(
             method="get",

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -88,6 +88,11 @@ class ResourceType(StrEnum):
 
 def strategy_create_kwargs() -> "list[tuple[str, dict[str, Any]]]":
     """Strategy to creation key-word-arguments."""
+    path_to_sample_json = STATIC_DIR / "sample.json"
+    assert path_to_sample_json.exists()
+    relative_postix_path_to_sample_json = path_to_sample_json.relative_to(
+        REPOSITORY_DIR
+    ).as_posix()
     return [
         (
             ResourceType.DATARESOURCE.value,
@@ -95,7 +100,7 @@ def strategy_create_kwargs() -> "list[tuple[str, dict[str, Any]]]":
                 "downloadUrl": (
                     "https://raw.githubusercontent.com/EMMC-ASBL/otelib"
                     f"/{HEAD_COMMIT_SHA}"
-                    f"/{(STATIC_DIR / 'sample.json').relative_to(REPOSITORY_DIR)}"
+                    f"/{relative_postix_path_to_sample_json}"
                 ),
                 "mediaType": "application/json",
             },

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,4 +1,7 @@
 """Utility functions for tests."""
+import json
+from pathlib import Path
+from subprocess import run
 from typing import TYPE_CHECKING
 
 try:
@@ -14,22 +17,12 @@ except ImportError:
 if TYPE_CHECKING:
     from typing import Any, Literal
 
+REPOSITORY_DIR = (Path(__file__).resolve().parent.parent).resolve()
+STATIC_DIR = (Path(__file__).resolve().parent / "static").resolve()
+HEAD_COMMIT_SHA = run(["git", "rev-parse", "HEAD"], capture_output=True).stdout.decode()
 
 TEST_DATA = {
-    "dataresource": {
-        "content": {
-            "firstName": "Joe",
-            "lastName": "Jackson",
-            "gender": "male",
-            "age": 28,
-            "address": {
-                "streetAddress": "101",
-                "city": "San Diego",
-                "state": "CA",
-            },
-            "phoneNumbers": [{"type": "home", "number": "7349282382"}],
-        }
-    },
+    "dataresource": {"content": json.loads((STATIC_DIR / "sample.json").read_text())},
     "filter": {"sqlquery": "DROP TABLE myTable;"},
     "function": {},
     "mapping": {
@@ -97,7 +90,11 @@ def strategy_create_kwargs() -> "list[tuple[str, dict[str, Any]]]":
         (
             ResourceType.DATARESOURCE.value,
             {
-                "downloadUrl": "https://filesamples.com/samples/code/json/sample2.json",
+                "downloadUrl": (
+                    "https://raw.githubusercontent.com/EMMC-ASBL/otelib"
+                    f"/{HEAD_COMMIT_SHA}"
+                    f"/{(STATIC_DIR / 'sample.json').relative_to(REPOSITORY_DIR)}"
+                ),
                 "mediaType": "application/json",
             },
         ),

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -19,7 +19,9 @@ if TYPE_CHECKING:
 
 REPOSITORY_DIR = (Path(__file__).resolve().parent.parent).resolve()
 STATIC_DIR = (Path(__file__).resolve().parent / "static").resolve()
-HEAD_COMMIT_SHA = run(["git", "rev-parse", "HEAD"], capture_output=True).stdout.decode()
+HEAD_COMMIT_SHA = run(
+    ["git", "rev-parse", "HEAD"], capture_output=True, check=True
+).stdout.decode()
 
 TEST_DATA = {
     "dataresource": {"content": json.loads((STATIC_DIR / "sample.json").read_text())},


### PR DESCRIPTION
# Description:
<!-- Summary of change, including the issue to be addressed. -->
Fixes #151 

Instead of using filesamples.com, the URL will point to the `sample.json` file under `tests/static/` added in this PR, through the raw.githubusercontent.com domain.
It will be a partially dynamic reference, in the sense that it will always use the file found in the tree of the current HEAD commit. Further, the relative path from the repository root to the sample file is explicitly resolved to hopefully make it clear where things should be changed if the tests API is changed.

## Type of change:
<!-- Put an `x` in the box that applies. -->
- [x] Bug fix.
- [ ] New feature.
- [ ] Documentation update.

## Checklist for the reviewer:
<!-- Put an `x` in the boxes that apply. These can be filled by reviewer after the PR is created. -->

This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
