### PR TITLE
Run safety via separate CI job

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -22,15 +22,28 @@ jobs:
       # pre-commit
       run_pre-commit: false
 
+      # pylint + safety
       run_pylint: false
-      run_safety: true
-      python_version_pylint_safety: "3.10"
+      run_safety: false
 
       # Build package
       run_build_package: true
       python_version_package: "3.10"
       build_libs: flit
       build_cmd: flit build
+
+  safety:
+    name: Safety
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout ${{ github.repository }}
+      uses: actions/checkout@v4
+
+    - name: Run Safety CLI to check for vulnerabilities
+      uses: pyupio/safety-action@v1
+      with:
+        api-key: ${{ secrets.SAFETY_API_TOKEN }}
 
   pytest:
     name: pytest (${{ matrix.os[1] }}, py${{ matrix.python-version }})

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -33,7 +33,7 @@ jobs:
       build_cmd: flit build
 
   pip-audit:
-    name: Safety
+    name: pip-audit
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -32,7 +32,7 @@ jobs:
       build_libs: flit
       build_cmd: flit build
 
-  safety:
+  pip-audit:
     name: Safety
     runs-on: ubuntu-latest
 
@@ -40,10 +40,21 @@ jobs:
     - name: Checkout ${{ github.repository }}
       uses: actions/checkout@v4
 
-    - name: Run Safety CLI to check for vulnerabilities
-      uses: pyupio/safety-action@v1
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v5
       with:
-        api-key: ${{ secrets.SAFETY_API_TOKEN }}
+        python-version: "3.10"
+
+    - name: Install python dependencies
+      run: |
+        python -m pip install -U pip
+        pip install -U setuptools wheel
+        pip install -e .[dev]
+
+    - name: Run pip-audit
+      uses: pypa/gh-action-pip-audit@v1.1.0
+      with:
+        local: true
 
   pytest:
     name: pytest (${{ matrix.os[1] }}, py${{ matrix.python-version }})


### PR DESCRIPTION
# Description
<!-- Summary of change, including the issue to be addressed. -->
~Run safety via its [dedicated github action](https://github.com/pyupio/safety-action)  instead of SINTEF/ci-cd.~

This change is mainly due to the usage of the deprecated `safety check` instead of the "new" `safety scan` option. However, the `safety scan` option requires a Safety user, ~hence, it is simply easier to use the pre-existing GitHub action developed by Safety.~

**Edit**: Run [`pip-audit`](https://github.com/pypa/pip-audit) instead of safety.

## AI Summary

This pull request modifies the CI workflow configuration in `.github/workflows/ci_tests.yml`, focusing on dependency security auditing and adjustments to pre-existing checks.

### CI workflow updates:

* **Added `pip-audit` job**: Introduced a new job named `pip-audit` to perform dependency vulnerability audits using the `pypa/gh-action-pip-audit` GitHub Action. This job includes steps for checking out the repository, setting up Python 3.10, installing dependencies, and running the audit.

* **Modified `run_safety` and `run_pylint` flags**: Disabled the `run_safety` flag and updated the `run_pylint` flag, indicating a shift in how dependency and code quality checks are managed.

## Type of change
<!-- Put an `x` in the box that applies. -->
- [ ] Bug fix.
- [ ] New feature.
- [ ] Documentation update.

## Checklist for the reviewer
<!-- Put an `x` in the boxes that apply. These can be filled by reviewer after the PR is created. -->

This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
