### PR TITLE
Group GH Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,13 @@ updates:
   labels:
     - CI/CD
     - skip-changelog
+  groups:
+    actions:
+      applies-to: version-updates
+      patterns: ["*"]
+    actions-security:
+      applies-to: security-updates
+      patterns: ["*"]
 - package-ecosystem: pip
   directories:
     - "/"
@@ -22,12 +29,9 @@ updates:
     - dependencies
     - skip-changelog
   groups:
-    python-dependencies:
+    python:
       applies-to: version-updates
-      dependency-type: production
-    python-dependencies-dev:
-      applies-to: version-updates
-      dependency-type: development
-    python-dependencies-security:
+      patterns: ["*"]
+    python-security:
       applies-to: security-updates
-      dependency-type: production
+      patterns: ["*"]


### PR DESCRIPTION
# Description
<!-- Summary of change, including the issue to be addressed. -->

## AI Summary

This pull request updates the Dependabot configuration to simplify and generalize how dependency update groups are defined for both GitHub Actions and Python dependencies. The changes consolidate previous group definitions and use pattern matching to apply rules more broadly.

**Dependabot group configuration improvements:**

* Added `actions` and `actions-security` groups for GitHub Actions dependencies, using wildcard patterns to match all dependencies for both version and security updates.
* Consolidated and renamed Python dependency groups to `python` and `python-security`, applying them to all dependencies using wildcard patterns for both version and security updates, replacing the previous split between production and development dependencies.

## Type of change
<!-- Put an `x` in the box that applies. -->
- [ ] Bug fix.
- [ ] New feature.
- [ ] Documentation update.

## Checklist for the reviewer
<!-- Put an `x` in the boxes that apply. These can be filled by reviewer after the PR is created. -->

This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
